### PR TITLE
fix: 修复时区问题 - 使用本地时间替代 UTC 时间

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,9 +206,9 @@ def checkin(qr_token):
         SELECT qr.*, ats.activity_code
         FROM qr_codes qr
         JOIN attendance_sessions ats ON qr.session_id = ats.id
-        WHERE qr.qr_token = ? AND qr.expires_at > CURRENT_TIMESTAMP
+        WHERE qr.qr_token = ? AND qr.expires_at > ?
         AND ats.is_active = 1
-    ''', (qr_token,))
+    ''', (qr_token, tz_now()))
     qr_code_row = cursor.fetchone()
 
     if not qr_code_row:

--- a/app_leave_points.py
+++ b/app_leave_points.py
@@ -151,9 +151,9 @@ def register_leave_points_routes(app, admin_required, password_change_required):
         new_status = 'approved' if action == 'approve' else 'rejected'
         cursor.execute('''
             UPDATE leave_requests
-            SET status = ?, approved_by = ?, approved_at = CURRENT_TIMESTAMP
+            SET status = ?, approved_by = ?, approved_at = ?
             WHERE id = ?
-        ''', (new_status, current_user.id, leave_id))
+        ''', (new_status, current_user.id, tz_now(), leave_id))
 
         # 注意：批准时不再关联session_id和添加积分，而是在结束活动时才处理
 


### PR DESCRIPTION
修复 `CURRENT_TIMESTAMP` 返回 UTC 时间而非正确时区时间的问题。

## 主要修改:
- 在数据库连接中注册自定义函数 `LOCAL_TIMESTAMP()` 返回本地时间
- 将所有表定义中的 `CURRENT_TIMESTAMP` 改为 `LOCAL_TIMESTAMP`
- 修复所有应用代码中的 SQL 查询使用 `tz_now()` 函数
- 确保所有时间戳都使用正确的时区 (Asia/Shanghai)

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)