### PR TITLE
fix: prevent users from creating duplicate leave requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,11 +103,15 @@ def index():
     leave_requests = cursor.fetchall()
     conn.close()
 
+    # Check if user has pending or approved leave requests that prevent new ones
+    blocking_leave_status = current_user.has_pending_or_approved_leave()
+
     return render_template('index.html',
                          system_title=system_title,
                          total_points=total_points,
                          points_history=points_history,
-                         leave_requests=leave_requests)
+                         leave_requests=leave_requests,
+                         blocking_leave_status=blocking_leave_status)
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():
@@ -303,6 +307,15 @@ def request_leave():
     """Request leave"""
     system_title = get_setting('system_title', '签到系统')
 
+    # Check if user has existing leave requests that prevent new ones
+    blocking_leave_status = current_user.has_pending_or_approved_leave()
+    if blocking_leave_status:
+        if blocking_leave_status == 'pending':
+            flash('请联系管理员完成上一次请假的审批！', 'error')
+        elif blocking_leave_status == 'approved':
+            flash('您有一个待使用的请假，在使用之前。您不能再请一次！', 'error')
+        return redirect(url_for('index'))
+
     if request.method == 'POST':
         leave_type = request.form.get('leave_type')
         reason = request.form.get('reason', '').strip()
@@ -314,6 +327,15 @@ def request_leave():
         if not reason:
             flash('请填写请假原因', 'error')
             return redirect(url_for('request_leave'))
+
+        # Double-check for blocking leave requests (in case someone submitted via direct POST)
+        blocking_status = current_user.has_pending_or_approved_leave()
+        if blocking_status:
+            if blocking_status == 'pending':
+                flash('请联系管理员完成上一次请假的审批！', 'error')
+            elif blocking_status == 'approved':
+                flash('您有一个待使用的请假，在使用之前。您不能再请一次！', 'error')
+            return redirect(url_for('index'))
 
         # Create leave request
         conn = get_db()

--- a/app.py
+++ b/app.py
@@ -311,9 +311,9 @@ def request_leave():
     blocking_leave_status = current_user.has_pending_or_approved_leave()
     if blocking_leave_status:
         if blocking_leave_status == 'pending':
-            flash('请联系管理员完成上一次请假的审批！', 'error')
+            flash('在新建请假申请之前，您需要先联系管理员完成上一次请假的审批！', 'error')
         elif blocking_leave_status == 'approved':
-            flash('您有一个待使用的请假，在使用之前。您不能再请一次！', 'error')
+            flash('您有一个待使用的请假，在使用之前，您不能再请一次！', 'error')
         return redirect(url_for('index'))
 
     if request.method == 'POST':

--- a/models.py
+++ b/models.py
@@ -164,3 +164,19 @@ class User(UserMixin):
         rows = cursor.fetchall()
         conn.close()
         return rows
+
+    def has_pending_or_approved_leave(self):
+        """Check if user has pending or approved leave requests that prevent new ones"""
+        conn = get_db()
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT status FROM leave_requests
+            WHERE user_id = ? AND status IN ('pending', 'approved')
+            LIMIT 1
+        ''', (self.id,))
+        row = cursor.fetchone()
+        conn.close()
+
+        if row:
+            return row['status']  # Returns 'pending' or 'approved'
+        return None

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,14 @@
         .btn-secondary:hover {
             background: #7f8c8d;
         }
+        .btn:disabled {
+            background: #bdc3c7;
+            color: #7f8c8d;
+            cursor: not-allowed;
+        }
+        .btn:disabled:hover {
+            background: #bdc3c7;
+        }
         .card {
             background: #fff;
             border-radius: 8px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,17 @@
     <p>学工号：{{ current_user.student_id }}</p>
     <p>当前积分：<strong style="font-size: 24px; color: #3498db;">{{ total_points }}</strong></p>
     <div style="margin-top: 20px;">
-        <a href="{{ url_for('request_leave') }}" class="btn">请假申请</a>
+        {% if blocking_leave_status %}
+            {% if blocking_leave_status == 'pending' %}
+                <button class="btn" disabled title="请联系管理员完成上一次请假的审批！">请假申请</button>
+                <p style="color: #e74c3c; font-size: 14px; margin-top: 10px;">请联系管理员完成上一次请假的审批！</p>
+            {% elif blocking_leave_status == 'approved' %}
+                <button class="btn" disabled title="您有一个待使用的请假，在使用之前。您不能再请一次！">请假申请</button>
+                <p style="color: #e74c3c; font-size: 14px; margin-top: 10px;">您有一个待使用的请假，在使用之前。您不能再请一次！</p>
+            {% endif %}
+        {% else %}
+            <a href="{{ url_for('request_leave') }}" class="btn">请假申请</a>
+        {% endif %}
         <a href="{{ url_for('change_password') }}" class="btn btn-secondary">修改密码</a>
     </div>
 </div>


### PR DESCRIPTION
Prevents users from creating new leave requests when they have existing pending or approved requests.

Changes:
- Add validation to check for pending/approved leave requests
- Disable leave request button on home page when blocked
- Add backend validation to leave request route
- Show appropriate error messages for different blocking states
- Add CSS styling for disabled buttons

Resolves #12

Generated with [Claude Code](https://claude.ai/claude-code)