### PR TITLE
Fix rename button JavaScript syntax error

### DIFF
--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -39,7 +39,7 @@
                 <td>{{ user.name }}</td>
                 <td>{{ user.created_at }}</td>
                 <td>
-                    <button onclick="showRenameModal({{ user.id }}, '{{ user.name }}')" class="btn" style="padding: 4px 8px; font-size: 12px;">更名</button>
+                    <button onclick="showRenameModal({{ user.id }}, {{ user.name | tojson }})" class="btn" style="padding: 4px 8px; font-size: 12px;">更名</button>
                     <form method="POST" action="{{ url_for('reset_user_password', user_id=user.id) }}" style="display: inline;">
                         <button type="submit" class="btn btn-secondary" style="padding: 4px 8px; font-size: 12px; margin-left: 4px;" onclick="return confirm('确定重置该用户密码为学工号吗？')">重置密码</button>
                     </form>


### PR DESCRIPTION
Fixes the rename button bug where user names with special characters caused JavaScript syntax errors.

## Changes
- Used Jinja2 tojson filter to properly escape user names in onclick handlers
- Prevents "missing ) after argument list" errors
- Ensures showRenameModal function works for all users regardless of name content

Resolves #14.

Generated with [Claude Code](https://claude.ai/code)