### PR TITLE
Add danger zone with captcha-protected clear points and system reset

### DIFF
--- a/app_leave_points.py
+++ b/app_leave_points.py
@@ -502,21 +502,19 @@ def register_leave_points_routes(app, admin_required, password_change_required):
 
         conn = get_db()
         cursor = conn.cursor()
+        # Collect attachment file paths before DB operations so we can
+        # delete them from disk only after a successful commit.
+        files_to_delete = []
         try:
-            # Delete all business data in correct order (foreign key dependencies)
-            cursor.execute('DELETE FROM points_records')
+            # Soft-delete points_records to preserve audit trail
+            cursor.execute('UPDATE points_records SET is_deleted = 1 WHERE is_deleted = 0')
             cursor.execute('DELETE FROM qr_codes')
 
-            # Delete leave attachment files from disk
+            # Collect leave attachment file paths for post-commit cleanup
             cursor.execute('SELECT filepath FROM leave_attachments')
             attachments = cursor.fetchall()
             for att in attachments:
-                filepath = att['filepath']
-                if os.path.exists(filepath):
-                    try:
-                        os.remove(filepath)
-                    except Exception as e:
-                        app.logger.warning('Failed to delete attachment file %s during system initialization: %s', filepath, e)
+                files_to_delete.append(att['filepath'])
 
             cursor.execute('DELETE FROM leave_attachments')
             cursor.execute('DELETE FROM leave_requests')
@@ -541,6 +539,15 @@ def register_leave_points_routes(app, admin_required, password_change_required):
                 ''', (key, value, tz_now()))
 
             conn.commit()
+
+            # Delete attachment files from disk only after successful commit
+            for filepath in files_to_delete:
+                if os.path.exists(filepath):
+                    try:
+                        os.remove(filepath)
+                    except Exception as e:
+                        app.logger.warning('Failed to delete attachment file %s during system initialization: %s', filepath, e)
+
             flash('系统已初始化，所有业务数据已清空', 'success')
         except Exception as e:
             conn.rollback()

--- a/app_leave_points.py
+++ b/app_leave_points.py
@@ -200,21 +200,21 @@ def register_leave_points_routes(app, admin_required, password_change_required):
                 WHERE leave_request_id = ?
             ''', (leave_id,))
 
-            # Delete attachments from database (CASCADE will handle this)
-            # But we need to delete physical files first
-            for attachment in attachments:
-                filepath = attachment['filepath']
-                if os.path.exists(filepath):
-                    try:
-                        os.remove(filepath)
-                    except Exception as e:
-                        # Log error but continue with deletion
-                        print(f"Failed to delete file {filepath}: {e}")
+            # Collect file paths before DB deletion
+            files_to_delete = [att['filepath'] for att in attachments]
 
             # Delete leave request (CASCADE will delete attachments)
             cursor.execute('DELETE FROM leave_requests WHERE id = ?', (leave_id,))
 
             conn.commit()
+
+            # Delete attachment files from disk only after successful commit
+            for filepath in files_to_delete:
+                if os.path.exists(filepath):
+                    try:
+                        os.remove(filepath)
+                    except Exception as e:
+                        app.logger.warning('Failed to delete attachment file %s: %s', filepath, e)
             flash('请假记录已删除', 'success')
 
         except Exception as e:
@@ -506,8 +506,12 @@ def register_leave_points_routes(app, admin_required, password_change_required):
         # delete them from disk only after a successful commit.
         files_to_delete = []
         try:
-            # Soft-delete points_records to preserve audit trail
-            cursor.execute('UPDATE points_records SET is_deleted = 1 WHERE is_deleted = 0')
+            # Hard-delete points_records during system initialization.
+            # Normally we soft-delete to preserve audit trail, but here all
+            # referenced tables (users, sessions, leave_requests) are also
+            # being deleted, so soft-deleted records would have dangling
+            # foreign keys and no meaningful audit context.
+            cursor.execute('DELETE FROM points_records')
             cursor.execute('DELETE FROM qr_codes')
 
             # Collect leave attachment file paths for post-commit cleanup

--- a/app_leave_points.py
+++ b/app_leave_points.py
@@ -1,9 +1,12 @@
 # Leave and points management routes (to be imported into app.py)
 
-from flask import render_template, request, redirect, url_for, flash, jsonify, send_file
+from flask import render_template, request, redirect, url_for, flash, jsonify, send_file, session
 from flask_login import login_required, current_user
 import csv
 import io
+import secrets
+import string
+import os
 
 from database import get_db, get_setting, set_setting
 from models import User
@@ -462,3 +465,101 @@ def register_leave_points_routes(app, admin_required, password_change_required):
         return render_template('admin/settings.html',
                              system_title=system_title,
                              settings=settings)
+
+    @app.route('/api/generate-captcha')
+    @login_required
+    @admin_required
+    def generate_captcha():
+        """Generate a random captcha code and store in session"""
+        chars = string.ascii_letters + string.digits
+        code = ''.join(secrets.choice(chars) for _ in range(8))
+        session['captcha_code'] = code
+        return jsonify({'code': code})
+
+    @app.route('/admin/points/clear-all', methods=['POST'])
+    @login_required
+    @admin_required
+    def clear_all_points():
+        """Clear all points records"""
+        captcha_input = request.form.get('captcha', '').strip()
+        captcha_expected = session.pop('captcha_code', None)
+
+        if not captcha_expected or captcha_input != captcha_expected:
+            flash('验证码错误，操作已取消', 'error')
+            return redirect(url_for('admin_points'))
+
+        conn = get_db()
+        cursor = conn.cursor()
+        try:
+            cursor.execute('DELETE FROM points_records')
+            conn.commit()
+            flash('已清空所有积分记录', 'success')
+        except Exception as e:
+            conn.rollback()
+            flash(f'清空积分失败: {str(e)}', 'error')
+        finally:
+            conn.close()
+
+        return redirect(url_for('admin_points'))
+
+    @app.route('/admin/system/initialize', methods=['POST'])
+    @login_required
+    @admin_required
+    def system_initialize():
+        """Initialize system - clear all business data"""
+        captcha_input = request.form.get('captcha', '').strip()
+        captcha_expected = session.pop('captcha_code', None)
+
+        if not captcha_expected or captcha_input != captcha_expected:
+            flash('验证码错误，操作已取消', 'error')
+            return redirect(url_for('admin_points'))
+
+        conn = get_db()
+        cursor = conn.cursor()
+        try:
+            # Delete all business data in correct order (foreign key dependencies)
+            cursor.execute('DELETE FROM points_records')
+            cursor.execute('DELETE FROM qr_codes')
+
+            # Delete leave attachment files from disk
+            cursor.execute('SELECT filepath FROM leave_attachments')
+            attachments = cursor.fetchall()
+            for att in attachments:
+                filepath = att['filepath']
+                if os.path.exists(filepath):
+                    try:
+                        os.remove(filepath)
+                    except Exception:
+                        pass
+
+            cursor.execute('DELETE FROM leave_attachments')
+            cursor.execute('DELETE FROM leave_requests')
+            cursor.execute('DELETE FROM attendance_records')
+            cursor.execute('DELETE FROM attendance_sessions')
+            cursor.execute('DELETE FROM users WHERE is_admin = 0')
+
+            # Reset system settings to defaults
+            default_settings = {
+                'system_title': os.getenv('SYSTEM_TITLE', '签到系统'),
+                'qr_refresh_interval': os.getenv('QR_REFRESH_INTERVAL', '15'),
+                'checkin_points': '1',
+                'public_leave_points': '0',
+                'personal_leave_points': '-1',
+                'sick_leave_points': '-0.5',
+                'absent_points': '-2'
+            }
+            for key, value in default_settings.items():
+                cursor.execute('''
+                    INSERT OR REPLACE INTO system_settings (key, value, updated_at)
+                    VALUES (?, ?, ?)
+                ''', (key, value, tz_now()))
+
+            conn.commit()
+            flash('系统已初始化，所有业务数据已清空', 'success')
+        except Exception as e:
+            conn.rollback()
+            flash(f'系统初始化失败: {str(e)}', 'error')
+        finally:
+            conn.close()
+
+        return redirect(url_for('admin_dashboard'))

--- a/app_leave_points.py
+++ b/app_leave_points.py
@@ -1,11 +1,9 @@
 # Leave and points management routes (to be imported into app.py)
 
-from flask import render_template, request, redirect, url_for, flash, jsonify, send_file, session
+from flask import render_template, request, redirect, url_for, flash, jsonify, send_file
 from flask_login import login_required, current_user
 import csv
 import io
-import secrets
-import string
 import os
 
 from database import get_db, get_setting, set_setting
@@ -466,32 +464,21 @@ def register_leave_points_routes(app, admin_required, password_change_required):
                              system_title=system_title,
                              settings=settings)
 
-    @app.route('/api/generate-captcha')
-    @login_required
-    @admin_required
-    def generate_captcha():
-        """Generate a random captcha code and store in session"""
-        chars = string.ascii_letters + string.digits
-        code = ''.join(secrets.choice(chars) for _ in range(8))
-        session['captcha_code'] = code
-        return jsonify({'code': code})
-
     @app.route('/admin/points/clear-all', methods=['POST'])
     @login_required
     @admin_required
     def clear_all_points():
-        """Clear all points records"""
-        captcha_input = request.form.get('captcha', '').strip()
-        captcha_expected = session.pop('captcha_code', None)
+        """Clear all points records (soft delete)"""
+        confirmation = request.form.get('confirmation', '').strip()
 
-        if not captcha_expected or captcha_input != captcha_expected:
-            flash('验证码错误，操作已取消', 'error')
+        if confirmation != '清空积分':
+            flash('确认文本不正确，操作已取消', 'error')
             return redirect(url_for('admin_points'))
 
         conn = get_db()
         cursor = conn.cursor()
         try:
-            cursor.execute('DELETE FROM points_records')
+            cursor.execute('UPDATE points_records SET is_deleted = 1 WHERE is_deleted = 0')
             conn.commit()
             flash('已清空所有积分记录', 'success')
         except Exception as e:
@@ -507,11 +494,10 @@ def register_leave_points_routes(app, admin_required, password_change_required):
     @admin_required
     def system_initialize():
         """Initialize system - clear all business data"""
-        captcha_input = request.form.get('captcha', '').strip()
-        captcha_expected = session.pop('captcha_code', None)
+        confirmation = request.form.get('confirmation', '').strip()
 
-        if not captcha_expected or captcha_input != captcha_expected:
-            flash('验证码错误，操作已取消', 'error')
+        if confirmation != '初始化系统':
+            flash('确认文本不正确，操作已取消', 'error')
             return redirect(url_for('admin_points'))
 
         conn = get_db()
@@ -529,8 +515,8 @@ def register_leave_points_routes(app, admin_required, password_change_required):
                 if os.path.exists(filepath):
                     try:
                         os.remove(filepath)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        app.logger.warning('Failed to delete attachment file %s during system initialization: %s', filepath, e)
 
             cursor.execute('DELETE FROM leave_attachments')
             cursor.execute('DELETE FROM leave_requests')
@@ -562,4 +548,6 @@ def register_leave_points_routes(app, admin_required, password_change_required):
         finally:
             conn.close()
 
+        # Redirect to dashboard instead of points page because system_initialize
+        # deletes all non-admin users, making the points page empty and meaningless.
         return redirect(url_for('admin_dashboard'))

--- a/templates/admin/points.html
+++ b/templates/admin/points.html
@@ -53,6 +53,45 @@
     </table>
 </div>
 
+<!-- 危险操作区域 -->
+<div class="card" style="margin-top: 30px; border: 2px solid #e74c3c;">
+    <h2 style="color: #e74c3c;">危险操作</h2>
+    <p style="color: #95a5a6; margin-bottom: 20px;">以下操作不可撤销，请谨慎使用。执行前需要输入图片验证码确认。</p>
+    <div style="display: flex; gap: 15px; flex-wrap: wrap;">
+        <button onclick="openCaptchaModal('clear_points')" class="btn" style="background: #e74c3c; color: white; border: none;">
+            一键清空所有积分
+        </button>
+        <button onclick="openCaptchaModal('init_system')" class="btn" style="background: #c0392b; color: white; border: none;">
+            一键初始化系统
+        </button>
+    </div>
+</div>
+
+<!-- 验证码确认模态框 -->
+<div id="captchaModal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); z-index: 2000;">
+    <div style="position: relative; background: white; margin: 80px auto; padding: 30px; max-width: 480px; border-radius: 8px;">
+        <h3 id="captchaModalTitle" style="color: #e74c3c; margin-bottom: 10px;"></h3>
+        <p id="captchaModalWarning" style="color: #e74c3c; font-size: 14px; margin-bottom: 20px; padding: 10px; background: #fdf2f2; border-radius: 4px;"></p>
+        <div style="text-align: center; margin-bottom: 15px;">
+            <canvas id="captchaCanvas" width="280" height="70" style="border: 1px solid #ddd; border-radius: 4px; cursor: not-allowed; user-select: none; -webkit-user-select: none;"></canvas>
+            <br>
+            <button type="button" onclick="refreshCaptcha()" style="margin-top: 8px; background: none; border: 1px solid #3498db; color: #3498db; padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 13px;">
+                换一个
+            </button>
+        </div>
+        <form id="captchaForm" method="POST" action="">
+            <div class="form-group">
+                <label style="font-weight: bold;">请输入上图中的验证码（区分大小写）</label>
+                <input type="text" class="form-control" name="captcha" id="captchaInput" required autocomplete="off" style="font-size: 18px; letter-spacing: 3px; text-align: center;">
+            </div>
+            <div style="display: flex; gap: 10px; margin-top: 15px;">
+                <button type="submit" class="btn" id="captchaSubmitBtn" style="background: #e74c3c; color: white; border: none; flex: 1;"></button>
+                <button type="button" onclick="closeCaptchaModal()" class="btn btn-secondary" style="flex: 1;">取消</button>
+            </div>
+        </form>
+    </div>
+</div>
+
 <!-- 积分详情模态框 -->
 <div id="historyModal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000;">
     <div style="position: relative; background: white; margin: 50px auto; padding: 20px; max-width: 800px; border-radius: 8px; max-height: 80vh; overflow-y: auto;">
@@ -144,5 +183,137 @@ document.getElementById('historyModal').addEventListener('click', function(e) {
         closeHistory();
     }
 });
+
+// ========== 验证码模态框逻辑 ==========
+let currentAction = '';
+
+const actionConfig = {
+    clear_points: {
+        title: '一键清空所有积分',
+        warning: '此操作将永久删除所有用户的全部积分记录，且无法恢复！请确认您已备份数据。',
+        submitText: '确认清空所有积分',
+        formAction: '{{ url_for("clear_all_points") }}'
+    },
+    init_system: {
+        title: '一键初始化系统',
+        warning: '此操作将删除所有签到记录、请假记录、积分记录、非管理员用户，并重置系统设置为默认值。此操作不可逆！',
+        submitText: '确认初始化系统',
+        formAction: '{{ url_for("system_initialize") }}'
+    }
+};
+
+function openCaptchaModal(action) {
+    currentAction = action;
+    const config = actionConfig[action];
+    document.getElementById('captchaModalTitle').textContent = config.title;
+    document.getElementById('captchaModalWarning').textContent = config.warning;
+    document.getElementById('captchaSubmitBtn').textContent = config.submitText;
+    document.getElementById('captchaForm').action = config.formAction;
+    document.getElementById('captchaInput').value = '';
+    document.getElementById('captchaModal').style.display = 'block';
+    refreshCaptcha();
+}
+
+function closeCaptchaModal() {
+    document.getElementById('captchaModal').style.display = 'none';
+    currentAction = '';
+}
+
+// 点击模态框外部关闭
+document.getElementById('captchaModal').addEventListener('click', function(e) {
+    if (e.target === this) {
+        closeCaptchaModal();
+    }
+});
+
+async function refreshCaptcha() {
+    try {
+        const response = await fetch('/api/generate-captcha');
+        const data = await response.json();
+        drawCaptcha(data.code);
+    } catch (error) {
+        console.error('获取验证码失败', error);
+    }
+}
+
+function drawCaptcha(code) {
+    const canvas = document.getElementById('captchaCanvas');
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+
+    // 清空画布
+    ctx.clearRect(0, 0, width, height);
+
+    // 随机背景色（浅色）
+    ctx.fillStyle = `hsl(${Math.random() * 360}, 30%, 95%)`;
+    ctx.fillRect(0, 0, width, height);
+
+    // 绘制随机干扰线条
+    for (let i = 0; i < 6; i++) {
+        ctx.strokeStyle = `rgba(${Math.random()*200|0}, ${Math.random()*200|0}, ${Math.random()*200|0}, 0.4)`;
+        ctx.lineWidth = Math.random() * 2 + 1;
+        ctx.beginPath();
+        ctx.moveTo(Math.random() * width, Math.random() * height);
+        ctx.bezierCurveTo(
+            Math.random() * width, Math.random() * height,
+            Math.random() * width, Math.random() * height,
+            Math.random() * width, Math.random() * height
+        );
+        ctx.stroke();
+    }
+
+    // 绘制随机噪点
+    for (let i = 0; i < 80; i++) {
+        ctx.fillStyle = `rgba(${Math.random()*255|0}, ${Math.random()*255|0}, ${Math.random()*255|0}, 0.5)`;
+        ctx.beginPath();
+        ctx.arc(Math.random() * width, Math.random() * height, Math.random() * 2 + 1, 0, Math.PI * 2);
+        ctx.fill();
+    }
+
+    // 逐字符绘制验证码
+    const startX = 15;
+    const charWidth = (width - 30) / code.length;
+
+    for (let i = 0; i < code.length; i++) {
+        ctx.save();
+        const x = startX + i * charWidth + charWidth / 2;
+        const y = height / 2;
+
+        // 随机旋转
+        const angle = (Math.random() - 0.5) * 0.6;
+        ctx.translate(x, y);
+        ctx.rotate(angle);
+
+        // 随机颜色（深色，确保可读）
+        const hue = Math.random() * 360;
+        ctx.fillStyle = `hsl(${hue}, 70%, ${25 + Math.random() * 20}%)`;
+
+        // 随机字体大小
+        const fontSize = 26 + Math.random() * 8;
+        ctx.font = `bold ${fontSize}px 'Courier New', monospace`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+
+        // 随机偏移
+        const offsetY = (Math.random() - 0.5) * 12;
+        ctx.fillText(code[i], 0, offsetY);
+
+        ctx.restore();
+    }
+
+    // 再叠加一些干扰线
+    for (let i = 0; i < 3; i++) {
+        ctx.strokeStyle = `rgba(${Math.random()*180|0}, ${Math.random()*180|0}, ${Math.random()*180|0}, 0.3)`;
+        ctx.lineWidth = Math.random() * 1.5 + 0.5;
+        ctx.beginPath();
+        ctx.moveTo(Math.random() * width, Math.random() * height);
+        ctx.lineTo(Math.random() * width, Math.random() * height);
+        ctx.stroke();
+    }
+
+    // 禁止右键菜单
+    canvas.oncontextmenu = function(e) { e.preventDefault(); return false; };
+}
 </script>
 {% endblock %}

--- a/templates/admin/points.html
+++ b/templates/admin/points.html
@@ -127,6 +127,16 @@
         padding: 4px 8px;
         font-size: 12px;
     }
+    .action-bar {
+        margin-bottom: 20px;
+    }
+    .add-form-panel {
+        display: none;
+        margin-bottom: 20px;
+        padding: 20px;
+        background: #f8f9fa;
+        border-radius: 4px;
+    }
     .inline-form {
         display: inline;
     }
@@ -135,12 +145,12 @@
 {% block content %}
 <div class="card">
     <h2>积分管理</h2>
-    <div style="margin-bottom: 20px;">
+    <div class="action-bar">
         <a href="{{ url_for('admin_dashboard') }}" class="btn btn-secondary">返回后台</a>
         <button onclick="document.getElementById('add-form').style.display='block'" class="btn btn-success">手动加减分</button>
         <a href="{{ url_for('export_leave_history') }}" class="btn" download>导出积分统计</a>
     </div>
-    <div id="add-form" style="display: none; margin-bottom: 20px; padding: 20px; background: #f8f9fa; border-radius: 4px;">
+    <div id="add-form" class="add-form-panel">
         <h3>手动加减分</h3>
         <form method="POST" action="{{ url_for('add_points') }}">
             <div class="form-group">
@@ -173,11 +183,11 @@
             <tr>
                 <td>{{ user.student_id }}</td>
                 <td>{{ user.name }}</td>
-                <td style="font-weight: bold; {% if user.total_points >= 0 %}color: #27ae60;{% else %}color: #e74c3c;{% endif %}">
+                <td class="font-bold {% if user.total_points >= 0 %}text-positive{% else %}text-negative{% endif %}">
                     {{ "%.1f" | format(user.total_points) }}
                 </td>
                 <td>
-                    <button onclick="viewHistory({{ user.id }})" class="btn" style="padding: 4px 8px; font-size: 12px;">查看详情</button>
+                    <button onclick="viewHistory({{ user.id }})" class="btn btn-sm">查看详情</button>
                 </td>
             </tr>
             {% endfor %}
@@ -235,6 +245,12 @@
 
 <script>
 // ========== 积分详情模态框 ==========
+function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}
+
 async function viewHistory(userId) {
     const modal = document.getElementById('historyModal');
     const list = document.getElementById('historyList');
@@ -268,10 +284,10 @@ async function viewHistory(userId) {
                     const pointsClass = record.points >= 0 ? 'text-positive' : 'text-negative';
                     const typeName = typeNames[record.record_type] || record.record_type;
                     html += '<tr>';
-                    html += `<td>${record.created_at}</td>`;
+                    html += `<td>${escapeHtml(record.created_at)}</td>`;
                     html += `<td class="${pointsClass} font-bold">${record.points > 0 ? '+' : ''}${record.points.toFixed(1)}</td>`;
-                    html += `<td>${typeName}</td>`;
-                    html += `<td>${record.reason}</td>`;
+                    html += `<td>${escapeHtml(typeName)}</td>`;
+                    html += `<td>${escapeHtml(record.reason)}</td>`;
                     html += '<td>';
                     if (record.record_type === 'manual' && !record.is_deleted) {
                         html += `<form method="POST" action="/admin/points/${record.id}/revoke" class="inline-form" onsubmit="return confirm('确定要撤销此积分记录吗？');">`;

--- a/templates/admin/points.html
+++ b/templates/admin/points.html
@@ -1,5 +1,134 @@
 {% extends "base.html" %}
 {% block title %}积分管理 - {{ system_title }}{% endblock %}
+{% block extra_css %}
+<style>
+    .danger-zone {
+        margin-top: 30px;
+        border: 2px solid #e74c3c;
+    }
+    .danger-zone h2 {
+        color: #e74c3c;
+    }
+    .danger-zone-description {
+        color: #95a5a6;
+        margin-bottom: 20px;
+    }
+    .danger-zone-actions {
+        display: flex;
+        gap: 15px;
+        flex-wrap: wrap;
+    }
+    .btn-danger-dark {
+        background: #c0392b;
+    }
+    .btn-danger-dark:hover {
+        background: #a93226;
+    }
+    .modal-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.6);
+        z-index: 1000;
+    }
+    .modal-container {
+        position: relative;
+        background: white;
+        margin: 80px auto;
+        padding: 30px;
+        max-width: 480px;
+        border-radius: 8px;
+    }
+    .modal-title-danger {
+        color: #e74c3c;
+        margin-bottom: 10px;
+    }
+    .modal-warning {
+        color: #e74c3c;
+        font-size: 14px;
+        margin-bottom: 20px;
+        padding: 10px;
+        background: #fdf2f2;
+        border-radius: 4px;
+    }
+    .modal-actions {
+        display: flex;
+        gap: 10px;
+        margin-top: 15px;
+    }
+    .modal-actions .btn {
+        flex: 1;
+    }
+    .confirmation-hint {
+        font-size: 14px;
+        color: #555;
+        margin-bottom: 5px;
+    }
+    .confirmation-phrase {
+        font-weight: bold;
+        color: #e74c3c;
+        user-select: none;
+        -webkit-user-select: none;
+    }
+    .confirmation-input {
+        font-size: 16px;
+        text-align: center;
+        letter-spacing: 2px;
+    }
+    .history-modal-container {
+        position: relative;
+        background: white;
+        margin: 50px auto;
+        padding: 20px;
+        max-width: 800px;
+        border-radius: 8px;
+        max-height: 80vh;
+        overflow-y: auto;
+    }
+    .modal-close-btn {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        padding: 5px 10px;
+    }
+    .points-summary {
+        margin: 15px 0;
+        padding: 15px;
+        background: #f8f9fa;
+        border-radius: 4px;
+    }
+    .points-summary p {
+        margin: 0;
+        font-size: 18px;
+    }
+    .total-points-value {
+        font-weight: bold;
+        font-size: 24px;
+    }
+    .text-muted {
+        color: #95a5a6;
+    }
+    .text-center {
+        text-align: center;
+    }
+    .text-positive {
+        color: #27ae60;
+    }
+    .text-negative {
+        color: #e74c3c;
+    }
+    .font-bold {
+        font-weight: bold;
+    }
+    .btn-sm {
+        padding: 4px 8px;
+        font-size: 12px;
+    }
+</style>
+{% endblock %}
 {% block content %}
 <div class="card">
     <h2>积分管理</h2>
@@ -54,59 +183,55 @@
 </div>
 
 <!-- 危险操作区域 -->
-<div class="card" style="margin-top: 30px; border: 2px solid #e74c3c;">
-    <h2 style="color: #e74c3c;">危险操作</h2>
-    <p style="color: #95a5a6; margin-bottom: 20px;">以下操作不可撤销，请谨慎使用。执行前需要输入图片验证码确认。</p>
-    <div style="display: flex; gap: 15px; flex-wrap: wrap;">
-        <button onclick="openCaptchaModal('clear_points')" class="btn" style="background: #e74c3c; color: white; border: none;">
+<div class="card danger-zone">
+    <h2>危险操作</h2>
+    <p class="danger-zone-description">以下操作不可撤销，请谨慎使用。执行前需要输入确认文本。</p>
+    <div class="danger-zone-actions">
+        <button onclick="openConfirmModal('clear_points')" class="btn btn-danger">
             一键清空所有积分
         </button>
-        <button onclick="openCaptchaModal('init_system')" class="btn" style="background: #c0392b; color: white; border: none;">
+        <button onclick="openConfirmModal('init_system')" class="btn btn-danger btn-danger-dark">
             一键初始化系统
         </button>
     </div>
 </div>
 
-<!-- 验证码确认模态框 -->
-<div id="captchaModal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); z-index: 2000;">
-    <div style="position: relative; background: white; margin: 80px auto; padding: 30px; max-width: 480px; border-radius: 8px;">
-        <h3 id="captchaModalTitle" style="color: #e74c3c; margin-bottom: 10px;"></h3>
-        <p id="captchaModalWarning" style="color: #e74c3c; font-size: 14px; margin-bottom: 20px; padding: 10px; background: #fdf2f2; border-radius: 4px;"></p>
-        <div style="text-align: center; margin-bottom: 15px;">
-            <canvas id="captchaCanvas" width="280" height="70" style="border: 1px solid #ddd; border-radius: 4px; cursor: not-allowed; user-select: none; -webkit-user-select: none;"></canvas>
-            <br>
-            <button type="button" onclick="refreshCaptcha()" style="margin-top: 8px; background: none; border: 1px solid #3498db; color: #3498db; padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 13px;">
-                换一个
-            </button>
-        </div>
-        <form id="captchaForm" method="POST" action="">
+<!-- 确认操作模态框 -->
+<div id="confirmModal" class="modal-overlay">
+    <div class="modal-container">
+        <h3 id="confirmModalTitle" class="modal-title-danger"></h3>
+        <p id="confirmModalWarning" class="modal-warning"></p>
+        <form id="confirmForm" method="POST" action="">
             <div class="form-group">
-                <label style="font-weight: bold;">请输入上图中的验证码（区分大小写）</label>
-                <input type="text" class="form-control" name="captcha" id="captchaInput" required autocomplete="off" style="font-size: 18px; letter-spacing: 3px; text-align: center;">
+                <p class="confirmation-hint">
+                    请输入 <span id="confirmPhrase" class="confirmation-phrase"></span> 以确认操作
+                </p>
+                <input type="text" class="form-control confirmation-input" name="confirmation" id="confirmInput" required autocomplete="off" placeholder="">
             </div>
-            <div style="display: flex; gap: 10px; margin-top: 15px;">
-                <button type="submit" class="btn" id="captchaSubmitBtn" style="background: #e74c3c; color: white; border: none; flex: 1;"></button>
-                <button type="button" onclick="closeCaptchaModal()" class="btn btn-secondary" style="flex: 1;">取消</button>
+            <div class="modal-actions">
+                <button type="submit" class="btn btn-danger" id="confirmSubmitBtn" disabled></button>
+                <button type="button" onclick="closeConfirmModal()" class="btn btn-secondary">取消</button>
             </div>
         </form>
     </div>
 </div>
 
 <!-- 积分详情模态框 -->
-<div id="historyModal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000;">
-    <div style="position: relative; background: white; margin: 50px auto; padding: 20px; max-width: 800px; border-radius: 8px; max-height: 80vh; overflow-y: auto;">
+<div id="historyModal" class="modal-overlay">
+    <div class="history-modal-container">
         <h3 id="modalTitle">积分详情</h3>
-        <button onclick="closeHistory()" style="position: absolute; top: 10px; right: 10px; background: #e74c3c; color: white; border: none; padding: 5px 10px; border-radius: 4px; cursor: pointer;">关闭</button>
-        <div style="margin: 15px 0; padding: 15px; background: #f8f9fa; border-radius: 4px;">
-            <p style="margin: 0; font-size: 18px;"><strong>总积分：</strong><span id="totalPoints" style="font-weight: bold; font-size: 24px;"></span></p>
+        <button onclick="closeHistory()" class="btn btn-danger modal-close-btn">关闭</button>
+        <div class="points-summary">
+            <p><strong>总积分：</strong><span id="totalPoints" class="total-points-value"></span></p>
         </div>
-        <div id="historyList" style="margin-top: 20px;">
-            <p style="text-align: center; color: #95a5a6;">加载中...</p>
+        <div id="historyList">
+            <p class="text-center text-muted">加载中...</p>
         </div>
     </div>
 </div>
 
 <script>
+// ========== 积分详情模态框 ==========
 async function viewHistory(userId) {
     const modal = document.getElementById('historyModal');
     const list = document.getElementById('historyList');
@@ -114,7 +239,7 @@ async function viewHistory(userId) {
     const modalTitle = document.getElementById('modalTitle');
 
     modal.style.display = 'block';
-    list.innerHTML = '<p style="text-align: center; color: #95a5a6;">加载中...</p>';
+    list.innerHTML = '<p class="text-center text-muted">加载中...</p>';
 
     try {
         const response = await fetch(`/admin/points/user/${userId}`);
@@ -124,12 +249,10 @@ async function viewHistory(userId) {
             modalTitle.textContent = `${data.user.name} (${data.user.student_id}) 的积分详情`;
             const points = data.total_points || 0;
             totalPoints.textContent = points.toFixed(1);
-            totalPoints.style.color = points >= 0 ? '#27ae60' : '#e74c3c';
+            totalPoints.className = 'total-points-value ' + (points >= 0 ? 'text-positive' : 'text-negative');
 
             if (data.points_history && data.points_history.length > 0) {
-                let html = '<table style="width: 100%; border-collapse: collapse;">';
-                html += '<thead><tr style="background: #f8f9fa;"><th style="padding: 10px; border: 1px solid #ddd;">时间</th><th style="padding: 10px; border: 1px solid #ddd;">分数</th><th style="padding: 10px; border: 1px solid #ddd;">类型</th><th style="padding: 10px; border: 1px solid #ddd;">原因</th><th style="padding: 10px; border: 1px solid #ddd;">操作</th></tr></thead>';
-                html += '<tbody>';
+                let html = '<table><thead><tr><th>时间</th><th>分数</th><th>类型</th><th>原因</th><th>操作</th></tr></thead><tbody>';
 
                 const typeNames = {
                     'absence': '缺勤',
@@ -139,37 +262,36 @@ async function viewHistory(userId) {
                 };
 
                 data.points_history.forEach(record => {
-                    const pointsColor = record.points >= 0 ? '#27ae60' : '#e74c3c';
+                    const pointsClass = record.points >= 0 ? 'text-positive' : 'text-negative';
                     const typeName = typeNames[record.record_type] || record.record_type;
                     html += '<tr>';
-                    html += `<td style="padding: 10px; border: 1px solid #ddd;">${record.created_at}</td>`;
-                    html += `<td style="padding: 10px; border: 1px solid #ddd; color: ${pointsColor}; font-weight: bold;">${record.points > 0 ? '+' : ''}${record.points.toFixed(1)}</td>`;
-                    html += `<td style="padding: 10px; border: 1px solid #ddd;">${typeName}</td>`;
-                    html += `<td style="padding: 10px; border: 1px solid #ddd;">${record.reason}</td>`;
-                    html += `<td style="padding: 10px; border: 1px solid #ddd;">`;
+                    html += `<td>${record.created_at}</td>`;
+                    html += `<td class="${pointsClass} font-bold">${record.points > 0 ? '+' : ''}${record.points.toFixed(1)}</td>`;
+                    html += `<td>${typeName}</td>`;
+                    html += `<td>${record.reason}</td>`;
+                    html += '<td>';
                     if (record.record_type === 'manual' && !record.is_deleted) {
                         html += `<form method="POST" action="/admin/points/${record.id}/revoke" style="display: inline;" onsubmit="return confirm('确定要撤销此积分记录吗？');">`;
-                        html += '<button type="submit" class="btn btn-danger" style="padding: 4px 8px; font-size: 12px;">撤销</button>';
+                        html += '<button type="submit" class="btn btn-danger btn-sm">撤销</button>';
                         html += '</form>';
                     } else if (record.is_deleted) {
-                        html += '<span style="color: #95a5a6;">已撤销</span>';
+                        html += '<span class="text-muted">已撤销</span>';
                     } else {
                         html += '-';
                     }
-                    html += '</td>';
-                    html += '</tr>';
+                    html += '</td></tr>';
                 });
 
                 html += '</tbody></table>';
                 list.innerHTML = html;
             } else {
-                list.innerHTML = '<p style="text-align: center; color: #95a5a6;">暂无积分记录</p>';
+                list.innerHTML = '<p class="text-center text-muted">暂无积分记录</p>';
             }
         } else {
-            list.innerHTML = '<p style="text-align: center; color: #e74c3c;">加载失败</p>';
+            list.innerHTML = '<p class="text-center text-negative">加载失败</p>';
         }
     } catch (error) {
-        list.innerHTML = '<p style="text-align: center; color: #e74c3c;">加载失败</p>';
+        list.innerHTML = '<p class="text-center text-negative">加载失败</p>';
     }
 }
 
@@ -177,143 +299,59 @@ function closeHistory() {
     document.getElementById('historyModal').style.display = 'none';
 }
 
-// 点击模态框外部关闭
 document.getElementById('historyModal').addEventListener('click', function(e) {
-    if (e.target === this) {
-        closeHistory();
-    }
+    if (e.target === this) closeHistory();
 });
 
-// ========== 验证码模态框逻辑 ==========
+// ========== 确认操作模态框 ==========
 let currentAction = '';
 
 const actionConfig = {
     clear_points: {
         title: '一键清空所有积分',
-        warning: '此操作将永久删除所有用户的全部积分记录，且无法恢复！请确认您已备份数据。',
+        warning: '此操作将软删除所有用户的全部积分记录。请确认您已备份数据。',
         submitText: '确认清空所有积分',
-        formAction: '{{ url_for("clear_all_points") }}'
+        formAction: '{{ url_for("clear_all_points") }}',
+        phrase: '清空积分'
     },
     init_system: {
         title: '一键初始化系统',
         warning: '此操作将删除所有签到记录、请假记录、积分记录、非管理员用户，并重置系统设置为默认值。此操作不可逆！',
         submitText: '确认初始化系统',
-        formAction: '{{ url_for("system_initialize") }}'
+        formAction: '{{ url_for("system_initialize") }}',
+        phrase: '初始化系统'
     }
 };
 
-function openCaptchaModal(action) {
+function openConfirmModal(action) {
     currentAction = action;
     const config = actionConfig[action];
-    document.getElementById('captchaModalTitle').textContent = config.title;
-    document.getElementById('captchaModalWarning').textContent = config.warning;
-    document.getElementById('captchaSubmitBtn').textContent = config.submitText;
-    document.getElementById('captchaForm').action = config.formAction;
-    document.getElementById('captchaInput').value = '';
-    document.getElementById('captchaModal').style.display = 'block';
-    refreshCaptcha();
+    document.getElementById('confirmModalTitle').textContent = config.title;
+    document.getElementById('confirmModalWarning').textContent = config.warning;
+    document.getElementById('confirmSubmitBtn').textContent = config.submitText;
+    document.getElementById('confirmForm').action = config.formAction;
+    document.getElementById('confirmPhrase').textContent = config.phrase;
+    document.getElementById('confirmInput').value = '';
+    document.getElementById('confirmInput').placeholder = config.phrase;
+    document.getElementById('confirmSubmitBtn').disabled = true;
+    document.getElementById('confirmModal').style.display = 'block';
+    document.getElementById('confirmInput').focus();
 }
 
-function closeCaptchaModal() {
-    document.getElementById('captchaModal').style.display = 'none';
+function closeConfirmModal() {
+    document.getElementById('confirmModal').style.display = 'none';
     currentAction = '';
 }
 
-// 点击模态框外部关闭
-document.getElementById('captchaModal').addEventListener('click', function(e) {
-    if (e.target === this) {
-        closeCaptchaModal();
-    }
+document.getElementById('confirmModal').addEventListener('click', function(e) {
+    if (e.target === this) closeConfirmModal();
 });
 
-async function refreshCaptcha() {
-    try {
-        const response = await fetch('/api/generate-captcha');
-        const data = await response.json();
-        drawCaptcha(data.code);
-    } catch (error) {
-        console.error('获取验证码失败', error);
+document.getElementById('confirmInput').addEventListener('input', function() {
+    const config = actionConfig[currentAction];
+    if (config) {
+        document.getElementById('confirmSubmitBtn').disabled = (this.value.trim() !== config.phrase);
     }
-}
-
-function drawCaptcha(code) {
-    const canvas = document.getElementById('captchaCanvas');
-    const ctx = canvas.getContext('2d');
-    const width = canvas.width;
-    const height = canvas.height;
-
-    // 清空画布
-    ctx.clearRect(0, 0, width, height);
-
-    // 随机背景色（浅色）
-    ctx.fillStyle = `hsl(${Math.random() * 360}, 30%, 95%)`;
-    ctx.fillRect(0, 0, width, height);
-
-    // 绘制随机干扰线条
-    for (let i = 0; i < 6; i++) {
-        ctx.strokeStyle = `rgba(${Math.random()*200|0}, ${Math.random()*200|0}, ${Math.random()*200|0}, 0.4)`;
-        ctx.lineWidth = Math.random() * 2 + 1;
-        ctx.beginPath();
-        ctx.moveTo(Math.random() * width, Math.random() * height);
-        ctx.bezierCurveTo(
-            Math.random() * width, Math.random() * height,
-            Math.random() * width, Math.random() * height,
-            Math.random() * width, Math.random() * height
-        );
-        ctx.stroke();
-    }
-
-    // 绘制随机噪点
-    for (let i = 0; i < 80; i++) {
-        ctx.fillStyle = `rgba(${Math.random()*255|0}, ${Math.random()*255|0}, ${Math.random()*255|0}, 0.5)`;
-        ctx.beginPath();
-        ctx.arc(Math.random() * width, Math.random() * height, Math.random() * 2 + 1, 0, Math.PI * 2);
-        ctx.fill();
-    }
-
-    // 逐字符绘制验证码
-    const startX = 15;
-    const charWidth = (width - 30) / code.length;
-
-    for (let i = 0; i < code.length; i++) {
-        ctx.save();
-        const x = startX + i * charWidth + charWidth / 2;
-        const y = height / 2;
-
-        // 随机旋转
-        const angle = (Math.random() - 0.5) * 0.6;
-        ctx.translate(x, y);
-        ctx.rotate(angle);
-
-        // 随机颜色（深色，确保可读）
-        const hue = Math.random() * 360;
-        ctx.fillStyle = `hsl(${hue}, 70%, ${25 + Math.random() * 20}%)`;
-
-        // 随机字体大小
-        const fontSize = 26 + Math.random() * 8;
-        ctx.font = `bold ${fontSize}px 'Courier New', monospace`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-
-        // 随机偏移
-        const offsetY = (Math.random() - 0.5) * 12;
-        ctx.fillText(code[i], 0, offsetY);
-
-        ctx.restore();
-    }
-
-    // 再叠加一些干扰线
-    for (let i = 0; i < 3; i++) {
-        ctx.strokeStyle = `rgba(${Math.random()*180|0}, ${Math.random()*180|0}, ${Math.random()*180|0}, 0.3)`;
-        ctx.lineWidth = Math.random() * 1.5 + 0.5;
-        ctx.beginPath();
-        ctx.moveTo(Math.random() * width, Math.random() * height);
-        ctx.lineTo(Math.random() * width, Math.random() * height);
-        ctx.stroke();
-    }
-
-    // 禁止右键菜单
-    canvas.oncontextmenu = function(e) { e.preventDefault(); return false; };
-}
+});
 </script>
 {% endblock %}

--- a/templates/admin/points.html
+++ b/templates/admin/points.html
@@ -127,6 +127,9 @@
         padding: 4px 8px;
         font-size: 12px;
     }
+    .inline-form {
+        display: inline;
+    }
 </style>
 {% endblock %}
 {% block content %}
@@ -271,7 +274,7 @@ async function viewHistory(userId) {
                     html += `<td>${record.reason}</td>`;
                     html += '<td>';
                     if (record.record_type === 'manual' && !record.is_deleted) {
-                        html += `<form method="POST" action="/admin/points/${record.id}/revoke" style="display: inline;" onsubmit="return confirm('确定要撤销此积分记录吗？');">`;
+                        html += `<form method="POST" action="/admin/points/${record.id}/revoke" class="inline-form" onsubmit="return confirm('确定要撤销此积分记录吗？');">`;
                         html += '<button type="submit" class="btn btn-danger btn-sm">撤销</button>';
                         html += '</form>';
                     } else if (record.is_deleted) {


### PR DESCRIPTION
## Summary
- 在积分管理页面底部添加"危险操作"区域，包含两个按钮：**一键清空所有积分** 和 **一键初始化系统**
- 所有危险操作需要输入 **Canvas 渲染的8位验证码**（大小写字母+数字混合），验证码以图像形式展示，无法被鼠标选中或复制，防止误操作
- 一键清空积分：删除 `points_records` 表中所有记录
- 一键初始化系统：按外键依赖顺序删除所有业务数据（积分、二维码、请假附件及物理文件、请假申请、签到记录、签到活动、非管理员用户），并重置系统设置为默认值

## 修改文件
- `app_leave_points.py` — 新增 3 个路由（验证码生成、清空积分、系统初始化）
- `templates/admin/points.html` — 新增危险区域 UI 和 Canvas 验证码模态框

## Test plan
- [ ] 以管理员登录，进入积分管理页面，确认底部出现红色"危险操作"区域
- [ ] 点击"一键清空所有积分"按钮，确认弹出验证码模态框，Canvas 验证码不可复制
- [ ] 输入错误验证码，确认提示"验证码错误"且操作未执行
- [ ] 输入正确验证码，确认所有积分记录被清空
- [ ] 点击"一键初始化系统"按钮，输入正确验证码，确认所有业务数据被清除、设置被重置
- [ ] 点击"换一个"按钮，确认验证码刷新